### PR TITLE
demo: try using xwayland before quitting on wayland

### DIFF
--- a/demo/source/x11window.d
+++ b/demo/source/x11window.d
@@ -23,6 +23,8 @@ private __gshared X11Window[Window] windowMap;
 void ConnectX11()
 {
     display = XOpenDisplay(null);
+    if (!display)
+        throw new Exception("couldn't open an X display");
 
     WM_DELETE_WINDOW = XInternAtom(display, "WM_DELETE_WINDOW", false);
     _NET_WM_NAME = XInternAtom(display, "_NET_WM_NAME", false);


### PR DESCRIPTION
I recently found this project and tried running the demo, and it refused to work right away because I'm using wayland. I had to comment out the lines where it quits after detecting wayland to get it to work. Other X-only software doesn't actively refuse to work when it detects a wayland compositor, and the result is that it ends up running on xwayland totally fine.

Instead of refusing to run on wayland, try to use xwayland, and only quit if that fails.